### PR TITLE
Add NIS as a valid option for all provider types

### DIFF
--- a/plugins/modules/dellemc_powerscale_accesszone.py
+++ b/plugins/modules/dellemc_powerscale_accesszone.py
@@ -145,7 +145,7 @@ options:
       provider_type:
         description:
         - Specifies the auth provider type which needs to be added or removed from access zone.
-        choices: ['local', 'file', 'ldap', 'ads']
+        choices: ['local', 'file', 'ldap', 'ads', 'nis']
         type: str
         required: True
   state:
@@ -690,7 +690,7 @@ def get_powerscale_accesszone_parameters():
         provider_state=dict(required=False, type='str', choices=['add', 'remove']),
         auth_providers=dict(required=False, type='list', elements='dict', options=dict(
             provider_name=dict(type='str', required=True),
-            provider_type=dict(type='str', required=True, choices=['local', 'file', 'ldap', 'ads'])
+            provider_type=dict(type='str', required=True, choices=['local', 'file', 'ldap', 'ads', 'nis'])
         )),
         state=dict(required=True, type='str', choices=['present', 'absent'])
     )

--- a/plugins/modules/dellemc_powerscale_group.py
+++ b/plugins/modules/dellemc_powerscale_group.py
@@ -59,7 +59,7 @@ options:
     - This option acts as a filter for all operations except creation.
     type: str
     default: 'local'
-    choices: [ 'local', 'file', 'ldap', 'ads']
+    choices: [ 'local', 'file', 'ldap', 'ads', 'nis']
   state:
     description:
     - The state option is used to determine whether the group
@@ -574,7 +574,7 @@ def get_powerscale_group_parameters():
         group_id=dict(required=False, type='str'),
         access_zone=dict(required=False, type='str', default='system'),
         provider_type=dict(required=False, type='str',
-                           choices=['local', 'file', 'ldap', 'ads'],
+                           choices=['local', 'file', 'ldap', 'ads', 'nis'],
                            default='local'),
         state=dict(required=True, type='str', choices=['present', 'absent']),
         users=dict(required=False, type='list', elements='dict'),

--- a/plugins/modules/dellemc_powerscale_smartquota.py
+++ b/plugins/modules/dellemc_powerscale_smartquota.py
@@ -71,7 +71,7 @@ options:
     - This option acts as a filter for all operations except creation.
     type: str
     default: 'local'
-    choices: [ 'local', 'file', 'ldap', 'ads']
+    choices: [ 'local', 'file', 'ldap', 'ads', nis ]
   quota:
     description:
     - Specifies Smart Quota parameters.
@@ -794,7 +794,7 @@ def get_powerscale_smartquota_parameters():
         group_name=dict(type='str'),
         access_zone=dict(type='str', default='system'),
         provider_type=dict(type='str', default='local',
-                           choices=['local', 'file', 'ldap', 'ads']),
+                           choices=['local', 'file', 'ldap', 'ads', 'nis']),
         quota_type=dict(required=True, type='str',
                         choices=['user', 'group', 'directory',
                                  'default-user', 'default-group']),

--- a/plugins/modules/dellemc_powerscale_smb.py
+++ b/plugins/modules/dellemc_powerscale_smb.py
@@ -74,7 +74,7 @@ options:
     - b)'permission' can be 'read'/''write'/'full'
     - c)'permission_type' can be 'allow'/'deny'
     - The fourth entry 'provider_type' is optional (default is 'local')
-    - d)'provider_type' can be 'local'/'file'/'ads'/'ldap'
+    - d)'provider_type' can be 'local'/'file'/'ads'/'ldap'/'nis'
     type: list
     elements: dict
   access_based_enumeration:

--- a/plugins/modules/dellemc_powerscale_user.py
+++ b/plugins/modules/dellemc_powerscale_user.py
@@ -63,7 +63,7 @@ options:
     - This option acts as a filter for all operations except creation.
     type: str
     default: 'local'
-    choices: [ 'local', 'file', 'ldap', 'ads']
+    choices: [ 'local', 'file', 'ldap', 'ads', 'nis' ]
   enabled:
     description:
     - Enabled is a bool variable which is used to enable or disable
@@ -751,7 +751,7 @@ def get_powerscale_user_parameters():
         password=dict(required=False, type='str', no_log=True),
         access_zone=dict(required=False, type='str', default='system'),
         provider_type=dict(required=False, type='str',
-                           choices=['local', 'file', 'ldap', 'ads'],
+                           choices=['local', 'file', 'ldap', 'ads', 'nis'],
                            default='local'),
         enabled=dict(required=False, type='bool'),
         primary_group=dict(required=False, type='str'),


### PR DESCRIPTION
Several modules exclude the NIS provider. This pull request adds in the NIS option to those modules.