### PR TITLE
[snapshot-util] remove date-util and urllib3 dependency.

### DIFF
--- a/plugins/module_utils/storage/dell/utils.py
+++ b/plugins/module_utils/storage/dell/utils.py
@@ -7,17 +7,6 @@ HAS_POWERSCALE_SDK = False
 isi_sdk = None
 IMPORT_PKGS_FAIL = []
 
-try:
-    import urllib3
-
-    urllib3.disable_warnings()
-except ImportError:
-    IMPORT_PKGS_FAIL.append("urllib3")
-
-try:
-    import dateutil.relativedelta  # noqa   # pylint: disable=unused-import
-except ImportError:
-    IMPORT_PKGS_FAIL.append("python-dateutil")
 
 try:
     from pkg_resources import parse_version

--- a/plugins/modules/synciqreports.py
+++ b/plugins/modules/synciqreports.py
@@ -558,6 +558,7 @@ class SyncIQReports(object):
         include_sub_reports = self.module.params['include_sub_reports']
         synciq_report = None
         synciq_sub_report_details = None
+        synciq_sub_report_detail = None
 
         if not id and not name:
             error_message = 'Please provide a valid report id or valid report name'

--- a/plugins/modules/synciqtargetreports.py
+++ b/plugins/modules/synciqtargetreports.py
@@ -557,6 +557,7 @@ class SyncIQTargetReports(object):
         include_sub_reports = self.module.params['include_sub_reports']
         synciq_target_report = None
         synciq_target_sub_report_details = None
+        synciq_target_sub_report_detail = None
 
         if not id and not name:
             error_message = 'Please provide a valid report id or valid report name'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
 isilon-sdk
-python-dateutil>=2.8.2
-urllib3>=1.26.7


### PR DESCRIPTION
# Description
Remove date-util and urllib3 dependency from the collection.
date-util has been replaced with python datetime library.
urllib3 is a transitive dependency for the collection, it is a required library for the sdk to make a API calls 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [x] I have performed Ansible Sanity test using --docker default
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Sanity
- [x] Playbook Run
