### PR TITLE
Info Doc update for filesystem

### DIFF
--- a/docs/modules/info.rst
+++ b/docs/modules/info.rst
@@ -763,7 +763,7 @@ Examples
             filter_operator: "equal"
             filter_value: "xxx"
 
-    - name: Get filesystem from PowerScale cluster
+    - name: Get filesystem (/ifs) from PowerScale cluster
       dellemc.powerscale.info:
         onefs_host: "{{ onefs_host }}"
         verify_ssl: "{{ verify_ssl }}"
@@ -771,7 +771,6 @@ Examples
         api_password: "{{ api_password }}"
         gather_subset:
           - filesystem
-        path: "<path>"
 
     - name: Get filesystem from PowerScale cluster with query parameters
       dellemc.powerscale.info:
@@ -787,7 +786,7 @@ Examples
             quota: true
             acl: true
             snapshot: true
-            path: "<path>"
+            path: "<path>" # If specified, return filesystem details under the specified path
 
     - name: Get filesystem from PowerScale cluster with query parameters along with filters
       dellemc.powerscale.info:
@@ -803,7 +802,7 @@ Examples
             quota: true
             acl: true
             snapshot: true
-            path: "<path>"
+            path: "<path>" # If specified, return filesystem details under the specified path
         filters:
           - filter_key: "name"
             filter_operator: "equal"
@@ -2298,6 +2297,10 @@ smart_quota (always, list, [{'container': True, 'description': '', 'efficiency_r
 
 file_system (always, list, [{'name': 'home'}, {'name': 'smb11'}])
   The filesystem details.
+
+  If path is not specified in query\_parameters, the filesystem /ifs details are returned.
+
+  If path is specified in query\_parameters, the filesystem details under the specified path are returned.
 
 
   name (, str, home)


### PR DESCRIPTION
# Description

Add the following statement:
- If path is not specified in query_parameters, the filesystem /ifs details are returned.
- If path is specified in query_parameters, the filesystem details under the specified path are returned.

Also update the code, so the `path` parameter is considered a legal parameter regardless of whether it starts with `/` or not.


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [x] I have performed Ansible Sanity test using --docker default
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Manual Test
Before the code change, if path starts with /, e.g. /ifs/home, nothing will return
![image](https://github.com/user-attachments/assets/d65d3c78-d1e0-40fd-857b-42c7091dc91d)
After fix, the sub directory info under ifs/home or /ifs/home will be returned
![image](https://github.com/user-attachments/assets/2079837b-e795-4620-b02a-41f75de3676b)
