### PR TITLE
Set isilon SDK version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-isilon-sdk
+isilon-sdk==0.3.0.1


### PR DESCRIPTION
# Description
Since isilon sdk 0.5.0 has lots of bugs, set isilon sdk version to 0.3.0.1

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [ ] I have performed Ansible Sanity test using --docker default
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
