### PR TITLE
Role bugfix

### DIFF
--- a/docs/modules/role.rst
+++ b/docs/modules/role.rst
@@ -46,13 +46,13 @@ Parameters
   description (optional, str, None)
     Specifies the description of the auth role.
 
-    Pass empty string to remove the \ :emphasis:`description`\ .
+    Pass empty string to remove the :emphasis:`description`.
 
 
   copy_role (optional, bool, None)
     Copy the role
 
-    \ :literal:`true`\  will copy the role from the \ :emphasis:`role\_name`\ .
+    :literal:`true` will copy the role from the :emphasis:`role\_name`.
 
 
   privileges (optional, list, None)
@@ -62,13 +62,15 @@ Parameters
     permission (optional, str, None)
       Specifies the permission being allowed for auth role.
 
-      \ :literal:`r`\  indicates read permission.
+      :literal:`+` indicates enabled permission, only for unary permission.
 
-      \ :literal:`w`\  indicates writepermission.
+      :literal:`r` indicates read permission.
 
-      \ :literal:`x`\  indicates execute permission.
+      :literal:`w` indicates writepermission.
 
-      \ :literal:`-`\  indicates none permission.
+      :literal:`x` indicates execute permission.
+
+      :literal:`-` indicates none permission.
 
 
     name (optional, str, None)
@@ -104,9 +106,9 @@ Parameters
   state (optional, str, present)
     Defines whether the auth role should exist or not.
 
-    Value \ :literal:`present`\  indicates that the auth role should exist in system.
+    Value :literal:`present` indicates that the auth role should exist in system.
 
-    Value \ :literal:`absent`\  indicates that the auth role should not exist in system.
+    Value :literal:`absent` indicates that the auth role should not exist in system.
 
 
   onefs_host (True, str, None)
@@ -120,9 +122,9 @@ Parameters
   verify_ssl (True, bool, None)
     boolean variable to specify whether to validate SSL certificate or not.
 
-    \ :literal:`true`\  - indicates that the SSL certificate should be verified.
+    :literal:`true` - indicates that the SSL certificate should be verified.
 
-    \ :literal:`false`\  - indicates that the SSL certificate should not be verified.
+    :literal:`false` - indicates that the SSL certificate should not be verified.
 
 
   api_user (True, str, None)
@@ -140,7 +142,7 @@ Notes
 -----
 
 .. note::
-   - The \ :emphasis:`check\_mode`\  is supported.
+   - The :emphasis:`check\_mode` is supported.
    - The modules present in this collection named as 'dellemc.powerscale' are built to support the Dell PowerScale storage platform.
 
 

--- a/plugins/modules/role.py
+++ b/plugins/modules/role.py
@@ -59,7 +59,7 @@ options:
       permission:
         description:
         - Specifies the permission being allowed for auth role.
-        - c(+) indicates enabled permission, only for unary permission.
+        - C(+) indicates enabled permission, only for unary permission.
         - C(r) indicates read permission.
         - C(w) indicates writepermission.
         - C(x) indicates execute permission.
@@ -529,7 +529,11 @@ class Role(PowerScaleBase):
 
     def get_privileges_to_update(self, existing_privileges, role_params, role_details_draft, existing_privileges_to_update):
         for item in role_params['privileges']:
-            privilege = [p for p in existing_privileges if p['name'] == item['name'] and (p['permission'] != item['permission'] and not (p['permission'] == '+' and item['permission'] != '-'))]
+            privilege = [
+                p for p in existing_privileges if p['name'] == item['name'] and \
+                (p['permission'] != item['permission'] and not \
+                (p['permission'] == '+' and item['permission'] != '-'))
+            ]
             if len(privilege) > 0:
                 item['id'] = privilege[0]['id']
                 existing_privileges_to_update.append(item)

--- a/plugins/modules/role.py
+++ b/plugins/modules/role.py
@@ -59,12 +59,13 @@ options:
       permission:
         description:
         - Specifies the permission being allowed for auth role.
+        - c(+) indicates enabled permission, only for unary permission.
         - C(r) indicates read permission.
         - C(w) indicates writepermission.
         - C(x) indicates execute permission.
         - C(-) indicates none permission.
         type: str
-        choices: ['r', 'x', 'w', '-']
+        choices: ['+', 'r', 'x', 'w', '-']
       name:
         description:
         - Specifies the name of the permission.
@@ -528,7 +529,7 @@ class Role(PowerScaleBase):
 
     def get_privileges_to_update(self, existing_privileges, role_params, role_details_draft, existing_privileges_to_update):
         for item in role_params['privileges']:
-            privilege = [p for p in existing_privileges if p['name'] == item['name'] and p['permission'] != item['permission']]
+            privilege = [p for p in existing_privileges if p['name'] == item['name'] and (p['permission'] != item['permission'] and not (p['permission'] == '+' and item['permission'] != '-'))]
             if len(privilege) > 0:
                 item['id'] = privilege[0]['id']
                 existing_privileges_to_update.append(item)
@@ -678,7 +679,7 @@ class Role(PowerScaleBase):
             description=dict(type='str'),
             privileges=dict(type='list', elements='dict', options=dict(
                             name=dict(type='str'),
-                            permission=dict(type='str', choices=['r', 'w', 'x', '-']),
+                            permission=dict(type='str', choices=['+', 'r', 'w', 'x', '-']),
                             state=dict(type='str', choices=['present', 'absent'], default='present'))),
             members=dict(type='list', elements='dict', options=dict(
                          name=dict(type='str'),

--- a/plugins/modules/role.py
+++ b/plugins/modules/role.py
@@ -530,9 +530,11 @@ class Role(PowerScaleBase):
     def get_privileges_to_update(self, existing_privileges, role_params, role_details_draft, existing_privileges_to_update):
         for item in role_params['privileges']:
             privilege = [
-                p for p in existing_privileges if p['name'] == item['name'] and \
-                (p['permission'] != item['permission'] and not \
-                (p['permission'] == '+' and item['permission'] != '-'))
+                p for p in existing_privileges
+                if p['name'] == item['name'] and (
+                    p['permission'] != item['permission'] and not (
+                        p['permission'] == '+' and item['permission'] != '-')
+                )
             ]
             if len(privilege) > 0:
                 item['id'] = privilege[0]['id']

--- a/tests/unit/plugins/module_utils/mock_role_api.py
+++ b/tests/unit/plugins/module_utils/mock_role_api.py
@@ -181,6 +181,36 @@ class MockRoleApi:
         ]
     }
 
+    GET_ROLE_RESPONSE_BACKUP_PLUS_SIG = {
+        "description": "This is role description",
+        "id": "Test_Role2",
+        "members": [
+            {
+                "id": "UID:1XXX",
+                "name": "admin",
+                "type": "user"
+            },
+            {
+                "id": "UID:2XXX",
+                "name": "esa",
+                "type": "user"
+            }
+        ],
+        "name": "Test_Role2",
+        "privileges": [
+            {
+                "id": "ISI_PRIV_AUDIT",
+                "name": "Audit",
+                "permission": "r"
+            },
+            {
+                "id": "ISI_PRIV_IFS_BACKUP",
+                "name": "Backup",
+                "permission": "+"
+            }
+        ]
+    }
+
     GET_EMPTY_ROLE_RESPONSE = {
         "description": "Test_Description",
         "id": "Test_Role1",
@@ -246,6 +276,30 @@ class MockRoleApi:
             "state": "present"
         }
     ]
+    PRIVILEGE_LIST_BACKUP_AUDIT = {
+        "privileges": [
+            {
+                "category": "Configuration",
+                "description": "Configure audit capabilities",
+                "id": "ISI_PRIV_AUDIT",
+                "name": "Audit",
+                "parent_id": "ISI_PRIV_ZERO",
+                "permission": "w",
+                "privilegelevel": "flag",
+                "uri": ""
+            },
+            {
+                "category": "File Access",
+                "description": "Backup files from /ifs",
+                "id": "ISI_PRIV_IFS_BACKUP",
+                "name": "Backup",
+                "parent_id": "ISI_PRIV_ZERO",
+                "permission": "r",
+                "privilegelevel": "flag",
+                "uri": ""
+            },
+        ]
+    }
     PRIVILEGE_LIST = {
         "privileges": [
             {

--- a/tests/unit/plugins/modules/test_role.py
+++ b/tests/unit/plugins/modules/test_role.py
@@ -319,6 +319,27 @@ class TestRole(PowerScaleUnitBase):
                              powerscale_module_mock.module.params)
         powerscale_module_mock.auth_api.update_auth_role.assert_called()
 
+    def test_modify_role_priveleges_plus_response(self, powerscale_module_mock):
+        self.set_module_params(self.role_args,
+                               {
+                                   "role_name": "Test_Role2",
+                                   "privileges": [
+                                       {
+                                           "name": "Backup",
+                                           "permission": "r",
+                                           "state": "present"
+                                       }
+                                   ]
+                               })
+        powerscale_module_mock.get_role_details = MagicMock(
+            return_value=MockRoleApi.GET_ROLE_RESPONSE_BACKUP_PLUS_SIG)
+        powerscale_module_mock.module.check_mode = False
+        powerscale_module_mock.auth_api.get_auth_privileges().to_dict = MagicMock(
+            return_value=MockRoleApi.PRIVILEGE_LIST_BACKUP_AUDIT)
+        RoleHandler().handle(powerscale_module_mock,
+                             powerscale_module_mock.module.params)
+        powerscale_module_mock.auth_api.update_auth_role.assert_not_called()
+
     def test_modify_role_priveleges_response_1(self, powerscale_module_mock):
         self.set_module_params(self.role_args,
                                {


### PR DESCRIPTION


# Description
Now support '+' as enabled, avoid idempotency issue
Rest API for PowerScale support + as enabled for unary permission

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [x] I have performed Ansible Sanity test using --docker default
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

