### PR TITLE
Remove ansible 2.15 from workflow and add python 3.12

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -48,9 +48,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11']
+        python: ['3.10', '3.11', '3.12']
         ansible:
-          - stable-2.15
           - stable-2.16
           - stable-2.17
           - stable-2.18
@@ -85,9 +84,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11']
+        python: ['3.10', '3.11', '3.12']
         ansible:
-          - stable-2.15
           - stable-2.16
           - stable-2.17
           - stable-2.18
@@ -115,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12"]
         ansible-version: [stable-2.18, devel]
 
     steps:


### PR DESCRIPTION
# Description
Due to failures in UT process, remove Ansible 2.15 which is not in support matrix from workflow combination
Add python 312 for workflow

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [ ] I have performed Ansible Sanity test using --docker default
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
