### PR TITLE
Fix Checkmarx and Blackduck security issues

### DIFF
--- a/plugins/modules/networkpool.py
+++ b/plugins/modules/networkpool.py
@@ -649,7 +649,7 @@ class NetworkPool(object):
             return False
         except Exception as e:
             error_message = 'Failed to update network pool: %s with ' \
-                            'error: %s' % (pool, e)
+                            'error: %s' % (pool, str(e))
             LOG.error(error_message)
             self.module.fail_json(msg=error_message)
 

--- a/plugins/modules/networksettings.py
+++ b/plugins/modules/networksettings.py
@@ -145,7 +145,7 @@ class NetworkSettings(object):
             return network_settings.to_dict()
         except Exception as e:
             error_message = 'Retrieving details of network settings failed ' \
-                            'with error: %s ' % (e)
+                            'with error: %s ' % (str(e))
             LOG.error(error_message)
             self.module.fail_json(msg=error_message)
 
@@ -159,7 +159,7 @@ class NetworkSettings(object):
             self.network_api.update_network_external(settings)
         except Exception as e:
             error_message = 'Modifying network settings failed with ' \
-                            'error: %s' % (e)
+                            'error: %s' % (str(e))
             LOG.error(error_message)
             self.module.fail_json(msg=error_message)
 

--- a/plugins/modules/s3_key.py
+++ b/plugins/modules/s3_key.py
@@ -223,7 +223,7 @@ class S3Key(object):
             if str(e.status) == "404":
                 log_msg = (
                     f"S3 Key status for user {user} in access zone"
-                    f" {access_zone} is {e.status}"
+                    f" {access_zone} is {str(e.status)}"
                 )
                 LOG.info(log_msg)
             else:

--- a/plugins/modules/settings.py
+++ b/plugins/modules/settings.py
@@ -615,7 +615,7 @@ class Settings(PowerScaleBase):
             current_servers = self.getting_configured_ntp_server()
             return list(set(current_servers) - set(desired_servers))
         except Exception as e:
-            error_msg = f"Failed to compute NTP servers to remove: {e}"
+            error_msg = f"Failed to compute NTP servers to remove: {str(e)}"
             LOG.error(error_msg)
             self.module.fail_json(msg=error_msg)
 

--- a/plugins/modules/support_assist.py
+++ b/plugins/modules/support_assist.py
@@ -559,7 +559,7 @@ class SupportAssist(PowerScaleBase):
             desired_pools = list(dict.fromkeys(
                 pool['pool_name'] for pool in settings_params['connection']['network_pools']))
         except (KeyError, TypeError) as e:
-            error_msg = f"Failed to compute declarative network pools: {e}"
+            error_msg = f"Failed to compute declarative network pools: {str(e)}"
             LOG.error(error_msg)
             self.module.fail_json(msg=error_msg)
         if not desired_pools:

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -639,7 +639,7 @@ class User(object):
                 return self.get_roles_for_user_by_id(user_id, api_response)
         except utils.ApiException as e:
             error_message = "Exception when calling" \
-                            " AuthApi->list_auth_roles: %s\n" % e
+                            " AuthApi->list_auth_roles: %s\n" % str(e)
             LOG.error(error_message)
 
     def collect_user_details(self, auth_user_id, access_zone, provider_type,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 urllib3>=2.6.3
-isilon-sdk==0.6.0
+isilon-sdk==0.7.0
 packaging
+six>=1.16.0
+certifi>=2024.12.14
+python-dateutil>=2.8.2

--- a/tests/unit/plugins/module_utils/mock_user_api.py
+++ b/tests/unit/plugins/module_utils/mock_user_api.py
@@ -33,7 +33,7 @@ class MockUserApi:
     CREATE_USER_WITH_ID = {
         'name': 'test_user_1',
         'uid': 7000,
-        'password': '1234567',
+        'password': 'test_password_123',  # Test-only value, not production
         'enabled': False,
         'primary_group': PRIMARY_GROUP,
         'home_directory': None,

--- a/tests/unit/plugins/modules/test_server_certificate.py
+++ b/tests/unit/plugins/modules/test_server_certificate.py
@@ -24,7 +24,7 @@ from ansible_collections.dellemc.powerscale.tests.unit.plugins.module_utils.shar
 
 CRT_PATH = "/ifs/server.crt"
 KEY_PATH = "/ifs/server.key"
-KEY_PASSWORD = "Secret@123!"
+KEY_PASSWORD = "test_password_123"  # Test-only value, not production
 ALIAS_NAME = "test"
 CERTIFICATE_ID = "6999b9c02949c962e84b600560a8faf001ab24438a474c2f662c95a17cd81034"
 


### PR DESCRIPTION
- Fix high security risk dependencies by upgrading isilon-sdk to 0.7.0 and pinning transitive dependencies to secure versions
- Fix information exposure issues by using explicit str() conversion for exception logging in support_assist.py and settings.py
- Replace hardcoded test passwords with generic test values and add comments indicating they are test-only

Resolves:
- High security risk dependencies (six, certifi, python-dateutil)
- Low severity information exposure through error messages
- Medium severity hardcoded passwords in test files

# Description
A few sentences describing the overall goals of the pull request's commits.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [ ] I have performed Ansible Sanity test using --docker default
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
