### PR TITLE
[ECS02C-1188]: Make smartquota state=absent idempotent when path does not exist

### DIFF
--- a/plugins/modules/smartquota.py
+++ b/plugins/modules/smartquota.py
@@ -731,8 +731,12 @@ class SmartQuota(object):
             LOG.info("Get Quota Details Failed. Quota does not exist.")
             return None, None
         except Exception as e:
+            error_str = determine_error(e)
+            if 'AEC_NOT_FOUND' in error_str:
+                LOG.info("Path %s not found, quota does not exist", path)
+                return None, None
             error_message = "Get Quota Details for %s failed with %s" \
-                            % (path, determine_error(e))
+                            % (path, error_str)
             LOG.error(error_message)
             self.module.fail_json(msg=error_message)
 


### PR DESCRIPTION
# Description
Fixes `powerscale_smartquota` so `state: absent` is idempotent when the target path does not exist. The PowerScale API returns `AEC_NOT_FOUND` for a missing path; `get_quota_details()` now catches this error and returns `(None, None)` instead of calling `fail_json()`.

# GitHub Issues

| GitHub Issue # |
| -------------- |
| #264 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [ ] I have performed Ansible Sanity test using --docker default
- [ ] I have verified that new and existing unit tests pass locally with my changes (15 pre-existing mock-setup failures unrelated to this change)
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?

- `python3 -m py_compile plugins/modules/smartquota.py` — pass
- Targeted AEC_NOT_FOUND unit validation — pass
- `ansible-galaxy collection build/install` — pass
- `ansible-doc dellemc.powerscale.smartquota` — pass
- `ansible-playbook --syntax-check` on all example playbooks — pass
